### PR TITLE
Fix connectiontimeout, etc.

### DIFF
--- a/chat/app/main/backend.py
+++ b/chat/app/main/backend.py
@@ -83,10 +83,10 @@ class User(object):
 
 class Messages(object):
     ChatExpired="Darn, you ran out of time! Waiting for a new chat..."
-    PartnerConnectionTimeout="Your partner's connection has timed out! Waiting for a new chat..."
+    PartnerConnectionTimeout="Your friend's connection has timed out! Waiting for a new chat..."
     ConnectionTimeout="Your connection has timed out! Waiting for a new chat..."
     YouLeftRoom="You have left the room. Waiting for a new chat..."
-    PartnerLeftRoom="Your partner has left the room! Waiting for a new chat..."
+    PartnerLeftRoom="Your friend has left the room! Waiting for a new chat..."
 
 
 class BackendConnection(object):
@@ -296,8 +296,8 @@ class BackendConnection(object):
                                                              partner_message=Messages.ChatExpired)
                     return False
                 except ConnectionTimeoutException:
-                    self._end_chat_and_transition_to_waiting(cursor, userid, u.partner_id, message=Messages.PartnerConnectionTimeout,
-                                                             partner_message=Messages.ConnectionTimeout)
+                    self._end_chat_and_transition_to_waiting(cursor, userid, u.partner_id, message=Messages.PartnerLeftRoom,
+                                                             partner_message=Messages.YouLeftRoom)
                     return False
 
                 return u.room_id == u2.room_id
@@ -339,7 +339,7 @@ class BackendConnection(object):
                         obj["name"] == restaurant_name)
 
         def _user_finished(cursor, userid, prev_points, my_points, other_points):
-            message = "Great, you've finished the chat! You scored {} points and your partner scored {} points.".format(
+            message = "Great, you've finished the chat! You scored {} points and your friend scored {} points.".format(
                 my_points, other_points)
             logger.info("Updating user %s to status FINISHED from status chat, with total points %d" % (userid[:6], prev_points+my_points))
             self._update_user(cursor, userid, status=Status.Finished, message=message,
@@ -452,7 +452,7 @@ class BackendConnection(object):
 
     def submit_single_task(self, userid, user_input):
         def _complete_task_and_wait(cursor, userid, num_finished):
-            message = "Great, you've finished {} exercises! Waiting a few seconds for a partner to chat with...".format(
+            message = "Great, you've finished {} exercises! Waiting a few seconds for someone to chat with...".format(
                 num_finished)
             logger.info("Updating user info for user %s after single task completion - transition to WAIT" % userid[:6])
             self._update_user(cursor, userid, status=Status.Waiting, message=message,
@@ -488,8 +488,8 @@ class BackendConnection(object):
                 cursor = self.conn.cursor()
                 logger.info("Removing user %s and partner from chat" % userid[:6])
                 u = self._get_user_info(cursor, userid, assumed_status=Status.Chat)
-                message = "You have left the room. Waiting for a new chat..."
-                partner_message = "Your partner has left the room! Waiting for a new chat..."
+                message = Messages.YouLeftRoom
+                partner_message = Messages.PartnerLeftRoom
                 logger.debug("Successfully retrieved user and partner information")
                 self._end_chat_and_transition_to_waiting(cursor, userid, u.partner_id, message=message,
                                                          partner_message=partner_message)

--- a/chat/app/main/backend.py
+++ b/chat/app/main/backend.py
@@ -149,7 +149,7 @@ class BackendConnection(object):
                     if u.status == Status.Waiting:
                         if isinstance(e, ConnectionTimeoutException):
                             logger.info("User %s had connection timeout in waiting state. Updating connection status to connected to reenter waiting state." % userid[:6])
-                            self._update_user(cursor, userid, connected_status=1)
+                            self._update_user(cursor, userid, connected_status=1, status=Status.Waiting)
                             return u.status
                         logger.info("User %s had status timeout in waiting state." % userid[:6])
                         self._transition_to_single_task(cursor, userid)
@@ -439,8 +439,8 @@ class BackendConnection(object):
         u = self._get_user_info_unchecked(cursor, userid)
         if assumed_status is not None:
             self._validate_status_or_throw(assumed_status, u.status)
-        self._assert_no_status_timeout(u.status, u.status_timestamp)
         self._assert_no_connection_timeout(u.connected_status, u.connected_timestamp)
+        self._assert_no_status_timeout(u.status, u.status_timestamp)
         return u
 
     def get_user_message(self, userid):
@@ -461,7 +461,7 @@ class BackendConnection(object):
             message = "Great, you've finished {} exercises!".format(num_finished)
             logger.info("Updating user info for user %s after single task completion - transition to FINISHED" % userid[:6])
             self._update_user(cursor, userid, status=Status.Finished, message=message,
-                              num_single_tasks_completed=num_finished)
+                              num_single_tasks_completed=0)
 
         def _log_user_submission(cursor, userid, scenario_id, user_input):
             logger.debug("Logging submission from user %s to database. Submission: %s" % (userid[:6], str(user_input)))

--- a/chat/app/main/backend.py
+++ b/chat/app/main/backend.py
@@ -149,7 +149,7 @@ class BackendConnection(object):
                     if u.status == Status.Waiting:
                         if isinstance(e, ConnectionTimeoutException):
                             logger.info("User %s had connection timeout in waiting state. Updating connection status to connected to reenter waiting state." % userid[:6])
-                            self._update_user(cursor, userid, connected_status=1, status=Status.Waiting)
+                            self._update_user(cursor, userid, connected_status=1, status=Status.Waiting, num_single_tasks_completed=0)
                             return u.status
                         logger.info("User %s had status timeout in waiting state." % userid[:6])
                         self._transition_to_single_task(cursor, userid)
@@ -157,7 +157,7 @@ class BackendConnection(object):
                     elif u.status == Status.SingleTask:
                         if isinstance(e, ConnectionTimeoutException):
                             logger.info("User %s had connection timeout in single task state. Updating connection status to connected and reentering waiting state." % userid[:6])
-                            self._update_user(cursor, userid, connected_status=1, status=Status.Waiting)
+                            self._update_user(cursor, userid, connected_status=1, status=Status.Waiting, num_single_tasks_completed=0)
                             return Status.Waiting
                         return u.status # this should never happen because single tasks can't time out
                     elif u.status == Status.Chat:
@@ -172,7 +172,7 @@ class BackendConnection(object):
                         return Status.Waiting
                     elif u.status == Status.Finished:
                         logger.info("User %s was previously in finished state. Updating to waiting state with connection status = connected." % userid[:6])
-                        self._update_user(cursor, userid, connected_status=1, status=Status.Waiting, message='')
+                        self._update_user(cursor, userid, connected_status=1, status=Status.Waiting, message='', num_single_tasks_completed=0)
                         return Status.Waiting
                     else:
                         raise Exception("Unknown status: {} for user: {}".format(u.status, userid))

--- a/chat/app/main/backend.py
+++ b/chat/app/main/backend.py
@@ -163,7 +163,8 @@ class BackendConnection(object):
                     elif u.status == Status.Chat:
                         if isinstance(e, ConnectionTimeoutException):
                             logger.info("User %s had connection timeout in chat state. Updating connection status to connected and reentering waiting state." % userid[:6])
-                            message = Messages.PartnerConnectionTimeout                            
+                            message = Messages.PartnerConnectionTimeout
+                            self._update_user(cursor, userid, num_single_tasks_completed=0)
                         else:
                             logger.info("Chat timed out for user %s. Leaving chat room and entering waiting state.." % userid[:6])
                             message = Messages.ChatExpired

--- a/chat/app/main/backend_utils.py
+++ b/chat/app/main/backend_utils.py
@@ -13,7 +13,7 @@ class WaitingSession(object):
         if message and len(message) > 0:
             self.message = message
         else:
-            self.message = "Please wait while we try to find a partner to pair you up with.."
+            self.message = "Please wait while we try to find someone to pair you up with.."
         self.num_seconds = num_seconds
 
 

--- a/chat/app/main/events.py
+++ b/chat/app/main/events.py
@@ -84,7 +84,7 @@ def text(message):
     write_to_file(msg)
     logger.debug("User %s said: %s" % (userid_prefix(), msg))
     emit_message_to_self("You: {}".format(msg))
-    emit_message_to_partner("Partner: {}".format(msg))
+    emit_message_to_partner("Friend: {}".format(msg))
 
 
 @socketio.on('pick', namespace='/chat')

--- a/chat/app/main/routes.py
+++ b/chat/app/main/routes.py
@@ -1,4 +1,4 @@
-from flask import session, render_template, request
+from flask import session, render_template, request, redirect, url_for
 from flask import current_app as app
 from . import main
 from .utils import get_backend
@@ -29,20 +29,38 @@ def userid():
     return session["sid"]
 
 
+def generate_unique_key():
+    return str(uuid.uuid4().hex)
+
+
+@main.route('/index', methods=['GET', 'POST'])
 @main.route('/', methods=['GET', 'POST'])
-@main.route('/game', methods=['GET', 'POST'])
-def main():
+def index():
     """Chat room. The user's name and room must be stored in
     the session."""
 
     set_or_get_userid()
-    # clear all chat session data
+
+    if not request.args.get('key'):
+        if request.args.get('mturk'):
+            return redirect(url_for('main.index', key=generate_unique_key(), mturk=request.args.get('mturk')))
+        else:
+            return redirect(url_for('main.index', key=generate_unique_key()))
+
     backend = get_backend()
     backend.create_user_if_necessary(userid())
 
+    key = request.args.get('key')
+    if 'key' in session and session['key'] != key and backend.is_connected(userid()):
+        return render_template('error.html')
+    elif 'key' not in session:
+        session['key'] = key
+
+
+
     status = backend.get_updated_status(userid())
     logger.info("Got updated status %s for user %s" % (Status._names[status], userid()[:6]))
-    session["mturk"] = True if request.args.get('mturk') else None
+    session["mturk"] = True if request.args.get('mturk') and request.args.get('mturk') == 1 else None
     if session["mturk"]:
         logger.debug("User %s is from Mechanical Turk" % userid()[:6])
     if status == Status.Waiting:

--- a/chat/app/main/routes.py
+++ b/chat/app/main/routes.py
@@ -51,8 +51,11 @@ def index():
     backend.create_user_if_necessary(userid())
 
     key = request.args.get('key')
-    if 'key' in session and session['key'] != key and backend.is_connected(userid()):
-        return render_template('error.html')
+    if 'key' in session and session['key'] != key:
+        if backend.is_connected(userid()):
+            return render_template('error.html')
+        else:
+            session['key'] = key
     elif 'key' not in session:
         session['key'] = key
 

--- a/chat/app/templates/chat.html
+++ b/chat/app/templates/chat.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <title>Negotiation Fun: {{ room }}</title>
+        <title>Negotiation Game: Where Should We Eat?</title>
 
 	<style>
 
@@ -64,6 +64,10 @@
 
 #clockdiv div > span{
     display: inline-block;
+}
+
+#clockdiv div > .seconds{
+	margin-left:-3px;
 }
 
 	</style>
@@ -161,7 +165,7 @@
     <body onload='init()'>
       <div class="clearfix">
     <div id="chat_container">
-        <h1>Where Should We Eat?</h1>
+        <h1>Negotiation Game: Where Should We Eat?</h1>
         <p>
             It's Friday night, and you and your friend are trying to figure out where to eat dinner.
             You've discovered that there are <b>{{scenario["restaurants"]|length}}</b> restaurants nearby.
@@ -178,8 +182,6 @@
 	  Time Remaining: 
 	  <div>
 	    <span class="minutes"></span>
-	  </div>
-	  <div>
 	    <span class="seconds"></span>
 	  </div>
 	</div>

--- a/chat/app/templates/error.html
+++ b/chat/app/templates/error.html
@@ -1,0 +1,13 @@
+<html>
+    <head>
+        <title>Negotiation Game: Where Should We Eat?</title>
+    </head>
+    <body>
+    <div id="content">
+        <h2>Error: Multiple Tabs Open</h2>
+        <h3>
+            You are already playing this game from another tab in your browser. Please complete the tasks in that tab before opening a new one.
+        </h3>
+    </div>
+    </body>
+</html>

--- a/chat/app/templates/finished.html
+++ b/chat/app/templates/finished.html
@@ -4,12 +4,12 @@
     </head>
     <body>
     <div id="content">
-        <h2>Negotiation Fun</h2>
+        <h2>Negotiation Game: Where Should We Eat?</h2>
         <h3>
             {{ finished_message }}
         </h3>
-        <hr>
         {% if mturk_code is not none %}
+		<hr>	
         <h3>Thanks for completing this HIT! Please copy and paste this code into the HIT on Mechanical Turk: {{ mturk_code }}</h3>
         {% endif %}
     </div>

--- a/chat/app/templates/single_task.html
+++ b/chat/app/templates/single_task.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <title>Negotiation Fun</title>
+        <title>Negotiation Game: Where Should We Eat?</title>
         <style>
 
 	  div#questions {
@@ -25,6 +25,10 @@
 	  }
 	  td {
 	  padding: 0 15px 0 15px;
+	  }
+	  
+	  .error {
+	  color: #ff0000;
 	  }
 	  
 	  table.sortable th:not(.sorttable_sorted):not(.sorttable_sorted_reverse):not(.sorttable_nosort):after { 
@@ -96,7 +100,7 @@
             Given your preferences and the different restaurant options, which restaurant would be your top choice?
         </h4>
 
-        <div id="choiceError" style="display:none"><h3>Please select a valid option below</h3></div>
+        <div id="choiceError" class="error" style="display:none"><h3>Please select a valid option below</h3></div>
         <select id="restaurantChoices">
             <option selected="selected" value=-1>-- Select one --</option>
             {% set ctr = 0 %}
@@ -106,9 +110,9 @@
             {% endfor %}
         </select>
         <h4>
-            What would your first negotiation move in the conversation be?
+            What is the first thing you would say to negotiate on a place to eat?
         </h4>
-        <div id="textError" style="display:none"><h3>Please enter your response in the box.</h3></div>
+        <div id="textError" class="error" style="display:none"><h3>Please enter your response in the box.</h3></div>
         <textarea id="starterText" rows="2" cols="50"></textarea>
         <button id="submit_task" onclick="validateAndSubmit();">
             Submit!

--- a/chat/app/templates/waiting.html
+++ b/chat/app/templates/waiting.html
@@ -17,6 +17,10 @@
 			font-size: 20px;	
 			display: inline-block;
 		}
+		
+		#timer div > .seconds{
+			margin-left:-3px;
+		}
     </style>
         <title>Negotiation Game: Where Should We Eat?</title>
         <script type="text/javascript" src="//code.jquery.com/jquery-1.4.2.min.js"></script>


### PR DESCRIPTION
@mkayser  I think these changes should fix 
1) the connection timeouts (we should always check for a connection timeout before we check for a status timeout, because a connection timeout implies we want to change state back to waiting, and we should always do that if needed
2) number of completed single tasks for each user - we weren't resetting this to 0  anywhere so I added that in - basically anytime someone leaves because of a connection timeout we want to reset the number of single tasks they've completed to 0 because we want to treat that as a brand new session and essentially "forget" all the tasks they've completed before.
